### PR TITLE
Ruby 1.8 compatability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Not released yet:
 
+* Ruby 1.8 compatability: use `Tempfile#path` when opening new file
+  instead passing `Tempfile` directly.
 * Rewind the file queued for write before returning it
 * Unlink the file **and** close the file descriptor when clearing
   the attachments

--- a/Rakefile
+++ b/Rakefile
@@ -4,4 +4,4 @@ require "bundler/gem_tasks"
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
-task default: :spec
+task :default => :spec

--- a/lib/paperclip/storage/tmp.rb
+++ b/lib/paperclip/storage/tmp.rb
@@ -20,7 +20,7 @@ module Paperclip
           @queued_for_write[style_name].rewind
           @queued_for_write[style_name]
         elsif exists?(style_name)
-          File.new(Tmp.fs[path(style_name)], 'rb')
+          File.new(Tmp.fs[path(style_name)].path, 'rb')
         end
       end
 

--- a/spec/fixtures/user.rb
+++ b/spec/fixtures/user.rb
@@ -1,3 +1,3 @@
 class User < ActiveRecord::Base
-  has_attached_file :avatar, storage: :tmp
+  has_attached_file :avatar, :storage => :tmp
 end

--- a/spec/lib/paperclip/storage/tmp_spec.rb
+++ b/spec/lib/paperclip/storage/tmp_spec.rb
@@ -7,7 +7,7 @@ describe Paperclip::Storage::Tmp do
 
   [proc { user.avatar }, proc { user.reload.avatar }].each do |subject_proc|
     describe 'assigning an attachment' do
-      let(:user) { User.create!(avatar: avatar_file) }
+      let(:user) { User.create!(:avatar => avatar_file) }
       subject(&subject_proc)
 
       it { should exist }
@@ -23,7 +23,7 @@ describe Paperclip::Storage::Tmp do
       end
 
       it 'copies the assigned file' do
-        File.read(subject.to_file).should eq(File.read(avatar_file))
+        File.read(subject.to_file.path).should eq(File.read(avatar_file.path))
       end
 
       it 'stores the file in an imagemagick-friendly way' do
@@ -39,17 +39,17 @@ describe Paperclip::Storage::Tmp do
       end
 
       it 'can handle assignment from File' do
-        new_user = User.new(avatar: avatar_file)
+        new_user = User.new(:avatar => avatar_file)
         new_user.avatar_file_name.should eq('hey_mom_its_me.png')
       end
 
       it 'can persist assignment from File' do
-        new_user = User.create!(avatar: avatar_file)
+        new_user = User.create!(:avatar => avatar_file)
         new_user.reload.avatar_file_name.should eq('hey_mom_its_me.png')
       end
 
       it 'can handle assignment from Paperclip::Attachment' do
-        new_user = User.new(avatar: subject)
+        new_user = User.new(:avatar => subject)
         new_user.avatar_file_name.should eq('hey_mom_its_me.png')
       end
     end
@@ -67,7 +67,7 @@ describe Paperclip::Storage::Tmp do
   end
 
   describe 'destroying an attachment' do
-    let(:user) { User.create!(avatar: avatar_file) }
+    let(:user) { User.create!(:avatar => avatar_file) }
     subject do
       @path_before_destroy = user.avatar.to_file.path
       user.destroy
@@ -84,7 +84,7 @@ describe Paperclip::Storage::Tmp do
   end
 
   describe 'clear' do
-    let(:user) { User.create!(avatar: avatar_file) }
+    let(:user) { User.create!(:avatar => avatar_file) }
     subject { Paperclip::Storage::Tmp.clear }
 
     it 'deletes files' do

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -2,7 +2,7 @@ require 'active_record'
 ActiveRecord::Base.send(:include, Paperclip::Glue)
 require 'fixtures/user'
 
-ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+ActiveRecord::Base.establish_connection(:adapter => 'sqlite3', :database => ':memory:')
 
 ActiveRecord::Schema.define do
   create_table :users do |t|


### PR DESCRIPTION
Hi!

I found issue when using Ruby 1.8 -

`File.new Tempfile.new("bla")` raises `can't convert Tempfile into String` exception

calling `#path` on tempfile ensures that `File.new` is called with String.

Tmp.fs should always return Tempfile right?
